### PR TITLE
Specify hosts to testinfa via python

### DIFF
--- a/molecule.yml
+++ b/molecule.yml
@@ -14,6 +14,3 @@ docker:
     image_version: '16.04'
     volume_mounts:
       - '/var/run/docker.sock:/var/run/docker.sock'
-
-testinfra:
-  hosts: 'ansible-role-molecule-wily,ansible-role-molecule-xenial'

--- a/tests/test_role.py
+++ b/tests/test_role.py
@@ -1,3 +1,8 @@
+from testinfra.utils.ansible_runner import AnsibleRunner
+
+testinfra_hosts = AnsibleRunner('.molecule/ansible_inventory').get_hosts('all')
+
+
 def test_molecule(Command):
     # Cleanup any previous run.
     Command('rm -rf ansible-role-apt')


### PR DESCRIPTION
Was specifying hosts via molecule.yml file. The new approach is dynamic and avoids repeating configuration information.
