### PR TITLE
Updated docs on min Ansible version

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Requirements
 
 * Ansible
 
-    * 2.0
+    * Minimum 2.0
     * Maximum 2.3 (currently using `always_run`, which is scheduled for removal
       in 2.4)
 


### PR DESCRIPTION
Make it clear that version 2.0 is only the minimum supported version and thus versions 2.1 and 2.2 are also supported.