### PR TITLE
Raised minimum Ansible version to 2.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ python: '2.7'
 
 # Spin off separate builds for each of the following versions of Ansible
 env:
-  - ANSIBLE_VERSION=2.0.2
   - ANSIBLE_VERSION=2.2.0
 
 # Require the standard build environment

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Requirements
 
 * Ansible
 
-    * Minimum 2.0
+    * Minimum 2.2
     * Maximum 2.3 (currently using `always_run`, which is scheduled for removal
       in 2.4)
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   description: Role for installing the Molecule test tool for Ansible.
   company: GantSign Ltd.
   license: MIT
-  min_ansible_version: 2.0
+  min_ansible_version: 2.2
   platforms:
   - name: Ubuntu
     versions:


### PR DESCRIPTION
To enable future use of `check_mode`.