### PR TITLE
Switched to Ansible 2.2 check mode support

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -18,7 +18,7 @@
   args:
     executable: /bin/bash
   register: available_molecule_versions
-  always_run: yes
+  check_mode: no
   changed_when: no
 
 - name: assert molecule version available


### PR DESCRIPTION
Dropped `always_run: yes`, which will be removed in Ansible 2.4 in favour of `check_mode: no`, which was added in Ansible 2.2.