### PR TITLE
Removed upper Ansible limit from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,6 @@ Requirements
 * Ansible
 
     * Minimum 2.2
-    * Maximum 2.3 (currently using `always_run`, which is scheduled for removal
-      in 2.4)
 
 * Ubuntu
 


### PR DESCRIPTION
Since the dependency on `always_run` has been removed there's currently no known upper Ansible version.