### PR TITLE
Workaround for pip 10 issue

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,13 +5,6 @@
     name: python-pip
     state: present
 
-- name: upgrade pip
-  become: yes
-  pip:
-    name: pip
-    state: present
-    extra_args: '--upgrade'
-
 # Query available Molecule versions and split one per line
 - name: query available molecule versions
   shell: "pip install molecule== &> >(sed -r 's/[^0-9\\.]*([0-9dev\\.]*)[^0-9\\.]*/\\1\\n/g' | sed '/^$/d') || $(exit 0)"


### PR DESCRIPTION
Pip 10 causes issues with standard packages on Ubuntu Xenial (see https://github.com/pypa/pip/issues/4805).