### PR TITLE
Workaround for Ansible dependency issue

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -52,6 +52,9 @@
   become: yes
   pip:
     name: docker
+    # 2018-04-16
+    # Limit version as workaround for: https://github.com/ansible/ansible/issues/35612
+    version: '2.7.0'
     state: present
 
 - name: install molecule


### PR DESCRIPTION
Ansible is incompatible with version 3.0.0 of the Python Docker library.