### PR TITLE
Increased minimum Ansible version to 2.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python: '2.7'
 
 # Spin off separate builds for each of the following versions of Ansible
 env:
-  - ANSIBLE_VERSION=2.3.3
+  - ANSIBLE_VERSION=2.4.6
   - ANSIBLE_VERSION=2.6.2
 
 # Require the standard build environment

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Requirements
 
 * Ansible
 
-    * Minimum 2.3
+    * Minimum 2.4
 
 * Ubuntu
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -5,7 +5,7 @@ galaxy_info:
   description: Role for installing the Molecule test tool for Ansible.
   company: GantSign Ltd.
   license: MIT
-  min_ansible_version: 2.3
+  min_ansible_version: 2.4
   platforms:
     - name: Ubuntu
       versions:


### PR DESCRIPTION
Ansible no longer support version 2.3 or earlier.