### PR TITLE
Removed Python Docker lib workaround

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,8 +30,7 @@ install:
   - pip install "ansible~=$ANSIBLE_VERSION"
 
   # Install Python API for Docker (required by Molecule Docker driver)
-  # Limit version as workaround for: https://github.com/ansible/ansible/issues/35612
-  - pip install 'docker<3.0'
+  - pip install docker
 
   # Install Molecule
   - pip install 'molecule==2.16.0'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -48,9 +48,6 @@
   become: yes
   pip:
     name: docker
-    # 2018-04-16
-    # Limit version as workaround for: https://github.com/ansible/ansible/issues/35612
-    version: '2.7.0'
     state: present
 
 - name: downgrade pip (pip 10 workaround)


### PR DESCRIPTION
Current versions of Ansible work with version 3 of the Python Docker library.