### PR TITLE
Resolved apt module syntax deprecation warning

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,11 +2,10 @@
 - name: install dependencies
   become: yes
   apt:
-    name: '{{ item }}'
+    name:
+      - python-pip
+      - libssl-dev
     state: present
-  with_items:
-    - python-pip
-    - libssl-dev
 
 # Query available Molecule versions and split one per line
 - name: query available molecule versions


### PR DESCRIPTION
```
[DEPRECATION WARNING]: Invoking "apt" only once while using a loop via
squash_actions is deprecated. Instead of using a loop to supply multiple items
and specifying `name: {{ item }}`, please use `name: [u'python-pip', u'libssl-
dev']` and remove the loop. This feature will be removed in version 2.11.
Deprecation warnings can be disabled by setting deprecation_warnings=False in
ansible.cfg.
```